### PR TITLE
AK1001: must close over `Sender` when using `PipeTo`

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
@@ -1,0 +1,72 @@
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotUseNewKeywordOnActorsAnalyzer>;
+
+namespace Akka.Analyzers.Tests.Analyzers.AK1000;
+
+public class MustCloseOverSenderWhenUsingPipeToSpecs
+{
+    public static readonly TheoryData<string> SuccessCases = new()
+    {
+        // ReceiveActor using PipeTo with a closure inside a Receive<string> block
+        @"using Akka.Actor;
+        using System.Threading.Tasks;
+
+        public sealed class MyActor : ReceiveActor{
+
+        public MyActor(){
+            Receive<string>(str => {
+             async Task<int> LocalFunction(){
+                  await Task.Delay(10);
+                  return str.Length;
+             }
+
+             // correct use of closure
+             var sender = Sender;
+             LocalFunction().PipeTo(sender); 
+         });
+        }
+      }",
+
+        // ReceiveActor using PipeTo calling a method from within a Receive<T> block
+        @"using Akka.Actor;
+        using System.Threading.Tasks;
+
+        public sealed class MyActor : ReceiveActor{
+
+        public MyActor(){
+            Receive<string>(str => {
+                Execute(str);
+            });
+        }
+
+        private void Execute(string str){
+           async Task<int> LocalFunction(){
+                  await Task.Delay(10);
+                  return str.Length;
+             }
+
+             // correct use of closure
+             var sender = Sender;
+             LocalFunction().PipeTo(sender); 
+        }
+    };",
+
+        // Actor doing message handling in a Receive<T> block without PipeTo at all
+        @"using Akka.Actor;
+        
+        public sealed class MyActor : ReceiveActor{
+
+            public MyActor(){
+                Receive<string>(str => {
+                    Sender.Tell(str); // shouldn't flag this
+                });
+            }
+        }"
+    };
+    
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public async Task SuccessCase(string testCode)
+    {
+        await Verify.VerifyAnalyzer(testCode).ConfigureAwait(true);
+    }
+}

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
@@ -1,4 +1,4 @@
-using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotUseNewKeywordOnActorsAnalyzer>;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustCloseOverSenderWhenUsingPipeToAnalyzer>;
 
 namespace Akka.Analyzers.Tests.Analyzers.AK1000;
 

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustCloseOverSenderWhenUsingPipeToAnalyzer>;
 
 namespace Akka.Analyzers.Tests.Analyzers.AK1000;
@@ -96,7 +97,10 @@ public class MustCloseOverSenderWhenUsingPipeToSpecs
     [MemberData(nameof(FailureCases))]
     public async Task FailureCase(string testCode)
     {
-        var expected = Verify.Diagnostic().WithSpan(12, 21, 12, 27);
+        var expected = Verify.Diagnostic()
+            .WithSpan(14, 37, 14, 43)
+            .WithArguments("Sender")
+            .WithSeverity(DiagnosticSeverity.Error);
         
         await Verify.VerifyAnalyzer(testCode, expected).ConfigureAwait(true);
     }

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorSpecs.cs
@@ -4,11 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using Akka.Analyzers.Tests.Utility;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing;
-using static Akka.Analyzers.RuleDescriptors;
 using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotUseNewKeywordOnActorsAnalyzer>;
 
 namespace Akka.Analyzers.Tests.Analyzers.AK1000;

--- a/src/Akka.Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzer.cs
+++ b/src/Akka.Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzer.cs
@@ -1,0 +1,62 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Akka.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MustCloseOverSenderWhenUsingPipeToAnalyzer() : AkkaDiagnosticAnalyzer(RuleDescriptors.Ak1001CloseOverSenderUsingPipeTo)
+{
+    public override void AnalyzeCompilation(CompilationStartAnalysisContext context, AkkaContext akkaContext)
+    {
+        Guard.AssertIsNotNull(context);
+        Guard.AssertIsNotNull(akkaContext);
+        
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            var classDeclaration = (ClassDeclarationSyntax)ctx.Node;
+            var semanticModel = ctx.SemanticModel;
+            var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
+
+            if (classSymbol is null || !classSymbol.IsActorBaseSubclass(akkaContext))
+                return; // not an actor, skip
+
+            // Analyze both methods and lambda expressions
+            var members = classDeclaration.DescendantNodes().OfType<MemberDeclarationSyntax>();
+            foreach (var member in members)
+            {
+                switch (member)
+                {
+                    case MethodDeclarationSyntax method:
+                        AnalyzeMethodOrLambda(ctx, method.Body);
+                        break;
+                    case PropertyDeclarationSyntax property:
+                        AnalyzeMethodOrLambda(ctx, property.AccessorList);
+                        break;
+                }
+            }
+
+        },SyntaxKind.ClassDeclaration);
+    }
+
+    private static void AnalyzeMethodOrLambda(SyntaxNodeAnalysisContext context, SyntaxNode? node)
+    {
+        if (node == null) return;
+        
+        var invocations = node.DescendantNodes().OfType<InvocationExpressionSyntax>();
+        foreach (var invocation in invocations)
+        {
+            if (invocation.Expression is not MemberAccessExpressionSyntax
+                {
+                    Name.Identifier.ValueText: "PipeTo"
+                } memberAccessExpr) continue;
+            
+            var dataFlow = context.SemanticModel.AnalyzeDataFlow(node);
+            if (!dataFlow.Captured.Any(symbol => symbol.Name == "Sender")) continue;
+            
+            var diagnostic = Diagnostic.Create(RuleDescriptors.Ak1001CloseOverSenderUsingPipeTo, memberAccessExpr.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Akka.Analyzers/Utility/CodeAnalysisExtensions.cs
+++ b/src/Akka.Analyzers/Utility/CodeAnalysisExtensions.cs
@@ -33,7 +33,7 @@ internal static class CodeAnalysisExtensions
         if(akkaContext.AkkaCore.ActorBaseType is null)
             return false;
         
-        var currentBaseType = typeSymbol.BaseType;
+        var currentBaseType = typeSymbol;
         while (currentBaseType != null)
         {
             if (SymbolEqualityComparer.Default.Equals(currentBaseType, akkaContext.AkkaCore.ActorBaseType))


### PR DESCRIPTION

## Changes

Not 100% sure that this is an issue in newer versions of Akka.NET, but it's still a good idea to enforce this.

Should flag the following code:

```csharp
using Akka.Actor;

public sealed class MyActor : ReceiveActor{
    Receive<string>(str => {
         async Task<int> LocalFunction(){
              await Task.Delay(10);
              return str.Length;
         }

         // invoke detatched async Task and PipeTo sender
         LocalFunction().PipeTo(Sender); // BUG: need to close over this.Sender using a local variable, because that value can change by the time the async function finishes evaluating.
     });
}
```