### PR TITLE
AK1001: `Sender` on non-actor classes

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToSpecs.cs
@@ -61,7 +61,34 @@ public class MustCloseOverSenderWhenUsingPipeToSpecs
                     Sender.Tell(str); // shouldn't flag this
                 });
             }
-        }"
+        }",
+        
+        // Non-Actor class that has an IActorRef Sender property
+        """
+        using Akka.Actor;
+        using System.Threading.Tasks;
+
+        public class MyActor
+        {
+            public MyActor(IActorRef sender)
+            {
+                Sender = sender;
+            }
+        
+            public IActorRef Sender { get; }
+            
+            public void Method()
+            {
+                async Task<int> LocalFunction(){
+                               await Task.Delay(10);
+                               return 11;
+                           }
+        
+                // Sender is immutable on this custom non-Actor class, so shouldn't flag this
+                LocalFunction().PipeTo(Sender); 
+            }
+        }
+        """,
     };
     
     [Theory]


### PR DESCRIPTION
Another happy path case we need to test:

validate that `IActorRef Sender` property on non-actor class doesn't triger AK1001. Added test case for this which passes.
